### PR TITLE
AWS CDK version upgrade from 1.0 to 2.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+cd pattern/aws-dynamodb-kinesisstreams-s3/ && npm install && npm run build && npm run test
+cd ../../sample-application/ && npm install && npm run build && cdk synth

--- a/pattern/aws-dynamodb-kinesisstreams-s3/lib/index.ts
+++ b/pattern/aws-dynamodb-kinesisstreams-s3/lib/index.ts
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import * as dynamodb from '@aws-cdk/aws-dynamodb'
-import { Construct } from '@aws-cdk/core'
 import { KinesisStreamsToKinesisFirehoseToS3, KinesisStreamsToKinesisFirehoseToS3Props } from '@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3'
 import * as defaults from '@aws-solutions-constructs/core'
-import * as lambda from '@aws-cdk/aws-lambda'
-import * as s3 from '@aws-cdk/aws-s3'
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
+import * as lambda from 'aws-cdk-lib/aws-lambda'
+import * as s3 from 'aws-cdk-lib/aws-s3'
+import { Construct } from 'constructs'
 import * as deepmerge from 'deepmerge'
 import { isPlainObject } from './utils'
 
@@ -73,7 +73,7 @@ export class AwsDynamoDBKinesisStreamsS3 extends Construct {
 
   /**
    * @summary Constructs a new instance of the AwsDynamodbKinesisStreamsS3 class.
-   * @param {cdk.Construct} scope - represents the scope for all the resources.
+   * @param {Construct} scope - represents the scope for all the resources.
    * @param {string} id - this is a a scope-unique id.
    * @param {AwsDynamoDBKinesisStreamsS3} props - user provided props for the construct.
    */
@@ -123,13 +123,13 @@ export class AwsDynamoDBKinesisStreamsS3 extends Construct {
       this.transformationLambda.grantInvoke(this.kinesisStreamsToKinesisFirehoseToS3.kinesisFirehoseRole)
     }
 
-    let dynamoTableProps: dynamodb.TableProps = {
+    let _dynamoTableProps: dynamodb.TableProps = {
       kinesisStream: this.kinesisStreamsToKinesisFirehoseToS3.kinesisStream,
       ...defaultTableProps
     }
 
     if (props.dynamoTableProps) {
-      dynamoTableProps = deepmerge(dynamoTableProps, props.dynamoTableProps,
+      _dynamoTableProps = deepmerge(_dynamoTableProps, props.dynamoTableProps,
         {
           arrayMerge: (target: any[], source: any[]) => {
             target = source
@@ -141,7 +141,7 @@ export class AwsDynamoDBKinesisStreamsS3 extends Construct {
 
     // Setup the DynamoDB table
     this.dynamoTable = defaults.buildDynamoDBTable(this, {
-      dynamoTableProps
-    })
+      dynamoTableProps: _dynamoTableProps,
+    })[1] as dynamodb.Table;
   }
 }

--- a/pattern/aws-dynamodb-kinesisstreams-s3/package.json
+++ b/pattern/aws-dynamodb-kinesisstreams-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-dynamodb-kinesisstreams-s3",
-  "version": "1.0.1",
+  "version": "2.0.1",
   "description": "CDK construct that streams Amazon DynamoDB records S3 using Amazon Kinesis Data Streams and Data Firehose.",
   "scripts": {
     "build": "tsc",
@@ -16,30 +16,28 @@
   },
   "license": "MIT-0",
   "devDependencies": {
-    "@aws-cdk/assert": "1.110.1",
-    "@types/jest": "^26.0.24",
-    "@types/node": "^16.0.1",
-    "@typescript-eslint/eslint-plugin": "^4.29.2",
-    "@typescript-eslint/parser": "^4.29.2",
-    "aws-cdk": "^1.135.0",
-    "eslint-config-standard": "^16.0.3",
-    "eslint-plugin-import": "^2.24.1",
-    "eslint-plugin-jest": "^24.4.0",
+    "@aws-cdk/assert": "^2.60.0",
+    "@types/jest": "^29.2.4",
+    "@types/node": "~18.11.15",
+    "@typescript-eslint/eslint-plugin": "^5.48.1",
+    "@typescript-eslint/parser": "^5.48.1",
+    "aws-cdk": "^2.60.0",
+    "eslint-config-standard": "^7.1.0",
+    "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0",
-    "jest": "^26.6.3",
-    "prettier": "^2.3.2",
-    "ts-jest": "^26.5.6",
-    "ts-node": "10.0.0",
-    "typescript": "^4.3.5"
+    "eslint-plugin-promise": "^6.1.1",
+    "jest": "^29.3.1",
+    "prettier": "^2.8.2",
+    "ts-jest": "^29.0.3",
+    "ts-node": "^10.9.1",
+    "typescript": "~4.9.4"
   },
   "dependencies": {
-    "@aws-cdk/aws-dynamodb": "1.110.1",
-    "@aws-cdk/aws-iam": "1.110.1",
-    "@aws-cdk/core": "1.110.1",
-    "@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3": "1.110.1",
-    "@aws-solutions-constructs/core": "1.110.1",
-    "deepmerge": "^4.0.0",
-    "source-map-support": "^0.5.16"
+    "aws-cdk-lib": "^2.60.0",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.21",
+    "@aws-solutions-constructs/aws-apigateway-dynamodb": "^2.30.0",
+    "@aws-solutions-constructs/aws-kinesisstreams-kinesisfirehose-s3": "^2.30.0",
+    "deepmerge": "^4.2.2"
   }
 }

--- a/pattern/aws-dynamodb-kinesisstreams-s3/test/index.test.ts
+++ b/pattern/aws-dynamodb-kinesisstreams-s3/test/index.test.ts
@@ -1,15 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import {expect as expectCDK, haveResource, ResourcePart} from '@aws-cdk/assert';
-import {AwsDynamoDBKinesisStreamsS3} from '../lib';
-import * as cdk from '@aws-cdk/core';
-import * as dynamodb from '@aws-cdk/aws-dynamodb'
+import { expect as expectCDK, haveResource, ResourcePart } from '@aws-cdk/assert';
+import { Stack } from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { AwsDynamoDBKinesisStreamsS3 } from '../lib';
 
 const modelName = 'SourceData';
 
 describe('AwsDynamoDBKinesisStreamsS3', () => {
-  const stack = new cdk.Stack();
+  const stack = new Stack();
 
   test('Default parameters creates a table with kinesis stream', () => {
     new AwsDynamoDBKinesisStreamsS3(stack, 'AwsDynamodbKinesisfirehoseS3Test', {

--- a/sample-application/bin/aws-serverless-dynamodb-s3-ingestion.ts
+++ b/sample-application/bin/aws-serverless-dynamodb-s3-ingestion.ts
@@ -2,10 +2,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
+import { App } from 'aws-cdk-lib';
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
-import {AwsServerlessDynamoDbS3IngestionStack} from '../lib/aws-serverless-dynamodb-s3-ingestion-stack';
+import { AwsServerlessDynamoDbS3IngestionStack } from '../lib/aws-serverless-dynamodb-s3-ingestion-stack';
 
-const app = new cdk.App();
+const app = new App();
 
 new AwsServerlessDynamoDbS3IngestionStack(app, 'AwsDynamodbKinesisfirehoseS3IngestionStack');

--- a/sample-application/cdk.json
+++ b/sample-application/cdk.json
@@ -1,17 +1,41 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/aws-serverless-dynamodb-s3-ingestion.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
   "context": {
-    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
-    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true
   }
 }

--- a/sample-application/lib/aws-serverless-dynamodb-s3-ingestion-stack.ts
+++ b/sample-application/lib/aws-serverless-dynamodb-s3-ingestion-stack.ts
@@ -1,20 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import * as dynamodb from '@aws-cdk/aws-dynamodb'
-import * as cdk from '@aws-cdk/core'
-import { Duration } from '@aws-cdk/core'
-import * as lambda from '@aws-cdk/aws-lambda'
-import * as apigateway from '@aws-cdk/aws-apigateway'
-import * as path from 'path'
 import { ApiGatewayToDynamoDB } from '@aws-solutions-constructs/aws-apigateway-dynamodb'
-import { AwsDynamoDBKinesisStreamsS3 } from 'aws-dynamodb-kinesisstreams-s3/lib'
+import { Duration, Stack, StackProps } from 'aws-cdk-lib'
+import * as apigateway from 'aws-cdk-lib/aws-apigateway'
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
+import * as lambda from 'aws-cdk-lib/aws-lambda'
+import { Construct } from 'constructs'
+import * as path from 'path'
+import { AwsDynamoDBKinesisStreamsS3 } from '../../pattern/aws-dynamodb-kinesisstreams-s3/lib'
 
-export class AwsServerlessDynamoDbS3IngestionStack extends cdk.Stack {
+export class AwsServerlessDynamoDbS3IngestionStack extends Stack {
   public readonly dynamodbKinesisS3: AwsDynamoDBKinesisStreamsS3;
   public readonly apiGatewayToDynamoDB: ApiGatewayToDynamoDB;
 
-  constructor (scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor (scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
     const modelName = 'SourceData'
 
@@ -23,7 +23,7 @@ export class AwsServerlessDynamoDbS3IngestionStack extends cdk.Stack {
       applyTransformation: true,
       transformationFunctionProps: {
         code: lambda.Code.fromAsset(path.join(__dirname, '..', 'lambda')),
-        runtime: lambda.Runtime.NODEJS_12_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         handler: 'index.handler',
         timeout: Duration.minutes(15)
       },

--- a/sample-application/package.json
+++ b/sample-application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-dynamodb-kinesisfirehose-s3-ingestion-sample-application",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "CDK application for sending Amazon DynamoDB Streams to an S3 bucket using Amazon Kinesis Data Streams and Data Firehose.",
   "private": true,
   "bin": {
@@ -20,31 +20,27 @@
   },
   "license": "MIT-0",
   "devDependencies": {
-    "@aws-cdk/assert": "1.110.1",
-    "@types/jest": "^26.0.24",
-    "@types/node": "^16.0.1",
-    "@typescript-eslint/eslint-plugin": "^4.29.2",
-    "@typescript-eslint/parser": "^4.29.2",
-    "aws-cdk": "^1.135.0",
-    "eslint": "^7.32.0",
-    "eslint-config-standard": "^16.0.3",
-    "eslint-plugin-import": "^2.24.1",
-    "eslint-plugin-jest": "^24.4.0",
+    "@aws-cdk/assert": "^2.60.0",
+    "@types/jest": "^29.2.4",
+    "@types/node": "^18.11.15",
+    "@typescript-eslint/eslint-plugin": "^5.48.1",
+    "@typescript-eslint/parser": "^5.48.1",
+    "aws-cdk": "^2.60.0",
+    "eslint-config-standard": "^7.1.0",
+    "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0",
-    "jest": "^26.6.3",
-    "prettier": "^2.3.2",
-    "ts-jest": "^26.5.6",
-    "ts-node": "10.0.0",
-    "typescript": "^4.3.5"
+    "eslint-plugin-promise": "^6.1.1",
+    "jest": "^29.3.1",
+    "prettier": "2.8.2",
+    "ts-jest": "^29.0.3",
+    "ts-node": "^10.9.1",
+    "typescript": "~4.9.4"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "1.110.1",
-    "@aws-cdk/aws-dynamodb": "1.110.1",
-    "@aws-cdk/core": "1.110.1",
-    "@aws-solutions-constructs/aws-apigateway-dynamodb": "1.110.1",
-    "@aws-solutions-constructs/core": "1.110.1",
-    "aws-dynamodb-kinesisstreams-s3": "1.0.1",
-    "source-map-support": "^0.5.16"
+    "@aws-solutions-constructs/aws-apigateway-dynamodb": "^2.30.0",
+    "aws-cdk-lib": "^2.60.0",
+    "aws-dynamodb-kinesisstreams-s3": "file:../pattern/aws-dynamodb-kinesisstreams-s3",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
*Issue #, CDK Version upgrade, V1.0 is in maintenance mode.*

*Description of changes:*
- CDK V1 is in maintenance mode, upgrading the CDK version and dependencies that is compatible with CDK 2.0.
- Additional build script added to easily build the project from home directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
