### PR TITLE
Updating aws-dynamodb-kinesisstreams-s3 version

### DIFF
--- a/sample-application/lib/aws-serverless-dynamodb-s3-ingestion-stack.ts
+++ b/sample-application/lib/aws-serverless-dynamodb-s3-ingestion-stack.ts
@@ -6,9 +6,9 @@ import { Duration, Stack, StackProps } from 'aws-cdk-lib'
 import * as apigateway from 'aws-cdk-lib/aws-apigateway'
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
+import { AwsDynamoDBKinesisStreamsS3 } from 'aws-dynamodb-kinesisstreams-s3/lib'
 import { Construct } from 'constructs'
 import * as path from 'path'
-import { AwsDynamoDBKinesisStreamsS3 } from '../../pattern/aws-dynamodb-kinesisstreams-s3/lib'
 
 export class AwsServerlessDynamoDbS3IngestionStack extends Stack {
   public readonly dynamodbKinesisS3: AwsDynamoDBKinesisStreamsS3;

--- a/sample-application/package.json
+++ b/sample-application/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aws-solutions-constructs/aws-apigateway-dynamodb": "^2.30.0",
     "aws-cdk-lib": "^2.60.0",
-    "aws-dynamodb-kinesisstreams-s3": "file:../pattern/aws-dynamodb-kinesisstreams-s3",
+    "aws-dynamodb-kinesisstreams-s3": "^2.0.1",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
*Description of changes:*

- Added and upgraded version for `aws-dynamodb-kinesisstreams-s3` instead of local import.
- Updated import for L3 construct `aws-dynamodb-kinesisstreams-s3`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
